### PR TITLE
Add hosts handling and admin account parsing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@
 #
 class ejabberd(
     $ensure                   = $ejabberd::params::ensure,
+    $hosts                    = $ejabberd::params::hosts,
     $log_level                = $ejabberd::params::log_level,
     $port_c2s                 = $ejabberd::params::port_c2s,
     $port_s2s                 = $ejabberd::params::port_s2s,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,9 @@ class ejabberd::params {
         default => $::ejabberd_ensure
     }
 
+    # managed hosts
+    $hosts = []
+
     # The Protocol used. Used by monitor and firewall class. Default is 'tcp'
     $log_level = $::ejabberd_loglevel ? {
         ''      => '4',

--- a/templates/ejabberd.cfg.erb
+++ b/templates/ejabberd.cfg.erb
@@ -95,7 +95,10 @@ override_acls.
 %% {hosts, ["example.net", "example.com", "example.org"]}.
 %%
 %% (This option is defined by debconf earlier)
-{hosts, ["<%= @fqdn %>"]}.
+{hosts, [<%- if @hosts.empty? !=true -%>
+<%- @hosts.each_with_index do |val, i| -%>"<%= val %>"<%= ", " if i < (@hosts.size - 1) %><%- end -%>
+<%- else -%>"<%= @fqdn %>"<%- end -%>
+]}.
 
 
 %%%   ===============
@@ -246,8 +249,15 @@ override_acls.
 %% The 'admin' ACL grants administrative privileges to Jabber accounts.
 %% You can put as many accounts as you want.
 %%
-<% @admin.each do |val| %>{acl, admin, {user, "<%= val %>", "<%= @fqdn %>"}}.
-<% end %>
+<%- @admin.each do |val|
+    curitem = val.split('@')
+    if curitem.size == 1 -%>
+{acl, admin, {user, "<%= val %>", "<%= @fqdn %>"}}.
+<%- else -%>
+{acl, admin, {user, "<%= curitem[0] %>", "<%= curitem[1] %>"}}.
+<%- end
+    end -%>
+
 
 %%
 %% Local users: don't modify this line.


### PR DESCRIPTION
Hi. First of all, thanks for sharing your work!

Please find the attached pull request that enables setting the hosts (instead of using fqdn, that still is used as a fallback if no host is specified).

Moreover, you can specify an admin account with its domain (in the form "user@domain"): I modified the template to parse the user and, if it finds an at-sign, split the user and use the two components for user and domain.

I used this patch in my ejabberd deployment that manages my domain. In that case, the fqdn of the server is absolutely wrong (it is in a private TLD)

Bye, Ugo
