### PR TITLE
Added support for "old style" XMPPS connections

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,8 @@ class ejabberd(
     $ensure                   = $ejabberd::params::ensure,
     $log_level                = $ejabberd::params::log_level,
     $port_c2s                 = $ejabberd::params::port_c2s,
+    $enable_xmpps             = $ejabberd::params::enable_xmpps,
+    $xmpps_port_c2s           = $ejabberd::params::xmpps_port_c2s,
     $port_s2s                 = $ejabberd::params::port_s2s,
     $port_http_admin          = $ejabberd::params::port_http_admin,
     $s2s_starttls             = $ejabberd::params::s2s_starttls,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,11 @@ class ejabberd::params {
         ''      => '5222',
         default => $::ejabberd_port_c2s,
     }
+    $enable_xmpps = false
+    $xmpps_port_c2s = $::ejabberd_xmpps_port_c2s ? {
+        ''      => '5223',
+        default => $::ejabberd_xmpps_port_c2s,
+    }
     $port_s2s = $::ejabberd_port_s2s ? {
         ''      => '5269',
         default => $::ejabberd_port_s2s,

--- a/templates/ejabberd.cfg.erb
+++ b/templates/ejabberd.cfg.erb
@@ -114,6 +114,15 @@ override_acls.
                         zlib,
 			starttls, {certfile, "<%= scope.lookupvar('ejabberd::certfile_path') %>"}
 		       ]},
+<%- if @enable_xmpps == true -%>
+  {<%= scope.lookupvar('ejabberd::xmpps_port_c2s') %>, ejabberd_c2s, [
+			{access, c2s},
+			{shaper, c2s_shaper},
+			{max_stanza_size, 65536},
+                        zlib,
+			tls, {certfile, "<%= scope.lookupvar('ejabberd::certfile_path') %>"}
+		       ]},
+<%- end -%>
 
   {<%= scope.lookupvar('ejabberd::port_s2s') %>, ejabberd_s2s_in, [
 			   {shaper, s2s_shaper},


### PR DESCRIPTION
Hi again ;)

In the case you need to handle XMPPS connections (old stype TLS, not STARTTLS ones), please consider this patch. Just set enable_xmpps to true!

Bye, Ugo
