### PR TITLE
Fix service notify (ejabberd has live, not status)

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -50,6 +50,7 @@ class ejabberd::common {
         ensure  => running,
         name    => $ejabberd::params::servicename,
         enable  => true,
+        status  => "service $ejabberd::params::servicename live",
         require => [
                     Package['ejabberd'],
                     File[$ejabberd::params::configfile],


### PR DESCRIPTION
Hi for the last time (for the moment ;)

On my Debian deployment, ejabberd service does not have the "status" command, but the "live".

This patch addresses the problem. Please take care that is absolutely Debian centric (I use "service")

Feel free to make it more generic. It works for me...

Bye, Ugo
